### PR TITLE
Add retry count fields to job

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,12 +11,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.17
+        go-version: 1.24
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/domonda/go-jobqueue
 
-go 1.23
+go 1.24
 
 require (
 	github.com/domonda/go-errs v0.0.0-20240702051036-0e696c849b5f

--- a/job.go
+++ b/job.go
@@ -15,11 +15,13 @@ type Job struct {
 	ID       uu.ID         `db:"id"        json:"id"`
 	BundleID uu.NullableID `db:"bundle_id" json:"bundleId"`
 
-	Type     string        `db:"type"     json:"type"` // CHECK(length("type") > 0 AND length("type") <= 100)
-	Payload  notnull.JSON  `db:"payload"  json:"payload"`
-	Priority int64         `db:"priority" json:"priority"`
-	Origin   string        `db:"origin"   json:"origin"`  // CHECK(length(origin) > 0 AND length(origin) <= 100)
-	StartAt  nullable.Time `db:"start_at" json:"startAt"` // If not NULL, earliest time to start the job
+	Type              string        `db:"type"     json:"type"` // CHECK(length("type") > 0 AND length("type") <= 100)
+	Payload           notnull.JSON  `db:"payload"  json:"payload"`
+	Priority          int64         `db:"priority" json:"priority"`
+	Origin            string        `db:"origin"   json:"origin"`  // CHECK(length(origin) > 0 AND length(origin) <= 100)
+	StartAt           nullable.Time `db:"start_at" json:"startAt"` // If not NULL, earliest time to start the job
+	MaxRetryCount     int           `db:"max_retry_count"   json:"maxRetryCount"`
+	CurrentRetryCount int           `db:"current_retry_count"   json:"currentRetryCount"`
 
 	StartedAt nullable.Time `db:"started_at" json:"startedAt"` // Time when started working on the job, or NULL when not started
 	StoppedAt nullable.Time `db:"stopped_at" json:"stoppedAt"` // Time when working on job was stoped because of a decision question or an error, or NULL


### PR DESCRIPTION
# Purpose
Prerequisite for https://github.com/domonda/go-jobqueue/pull/2

This needs to be done before modifyig the schema, otherwise the db layer can throw errors while trying to scan fields which aren't declared in the struct.