### PR TITLE
Add configurable job timeout to worker context

### DIFF
--- a/jobworker/config.go
+++ b/jobworker/config.go
@@ -3,6 +3,7 @@ package jobworker
 import (
 	"context"
 	"reflect"
+	"time"
 
 	"github.com/domonda/golog"
 	rootlog "github.com/domonda/golog/log"
@@ -14,6 +15,10 @@ var (
 	// OnError will be called for every error that
 	// would also be logged.
 	OnError = func(error) {}
+
+	// JobTimeout is the timeout applied to the context passed to job worker functions.
+	// Default is 15 minutes. Set to 0 to disable the timeout.
+	JobTimeout = 15 * time.Minute
 
 	typeOfError   = reflect.TypeOf((*error)(nil)).Elem()
 	typeOfContext = reflect.TypeOf((*context.Context)(nil)).Elem()

--- a/jobworker/dojob.go
+++ b/jobworker/dojob.go
@@ -40,6 +40,14 @@ func DoJob(ctx context.Context, job *jobqueue.Job) (err error) {
 	}
 
 	jobCtx := golog.ContextWithAttribs(ctx, golog.NewUUID("jobID", job.ID))
+
+	// Apply timeout if configured
+	if JobTimeout > 0 {
+		var cancel context.CancelFunc
+		jobCtx, cancel = context.WithTimeout(jobCtx, JobTimeout)
+		defer cancel()
+	}
+
 	result, jobErr := worker(jobCtx, job)
 	if jobErr != nil {
 		errorTitle := errs.Root(jobErr).Error()


### PR DESCRIPTION
## Summary
This change introduces a configurable timeout mechanism for job worker functions by adding a `JobTimeout` configuration variable that is applied to the context passed to workers.

## Key Changes
- Added `JobTimeout` configuration variable (default: 15 minutes) to `config.go`
  - Can be set to 0 to disable the timeout
  - Includes documentation explaining its purpose
- Modified `DoJob()` in `dojob.go` to apply the timeout to the job context
  - Creates a new context with timeout using `context.WithTimeout()`
  - Properly defers cancellation to ensure cleanup

## Implementation Details
- The timeout is applied after the job context is enriched with job ID attributes, ensuring the timeout wraps the actual job execution
- The timeout only applies if `JobTimeout > 0`, allowing users to opt-out by setting it to 0
- The cancel function is properly deferred to prevent context leaks
- This provides a safety mechanism to prevent jobs from running indefinitely

https://claude.ai/code/session_01M6Z9JYhYr1HJHdahGuw5tF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job execution timeout configuration is now available. Jobs are now subject to a configurable timeout with a default limit of 15 minutes. Users can adjust the timeout duration or disable it entirely by setting the configuration to 0 for unlimited execution time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->