### PR TITLE
docs: document all exported Go names

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -9,8 +9,13 @@ import (
 )
 
 const (
+	// ErrNotInitialized is returned by Service operations when no job queue
+	// service has been initialized. It is the error wrapped by the default
+	// service until SetDefaultService installs a real one.
 	ErrNotInitialized errs.Sentinel = "jobqueue service not initialized"
-	ErrClosed         errs.Sentinel = "jobqueue is closed"
+
+	// ErrClosed is returned by Service operations after the service has been closed.
+	ErrClosed errs.Sentinel = "jobqueue is closed"
 )
 
 var _ Service = errService{}
@@ -19,6 +24,10 @@ type errService struct {
 	err error
 }
 
+// ServiceWithError returns a Service whose every method returns the given err.
+// It is used as a placeholder default service before a real one is installed
+// with SetDefaultService, so that calls fail with a clear error such as
+// ErrNotInitialized instead of a nil pointer panic.
 func ServiceWithError(err error) Service {
 	return errService{err}
 }

--- a/job.go
+++ b/job.go
@@ -28,16 +28,16 @@ import (
 type Job struct {
 	db.TableName `db:"worker.job"`
 
-	ID       uu.ID         `db:"id,primarykey" json:"id"`
-	BundleID uu.NullableID `db:"bundle_id"     json:"bundleId"`
+	ID       uu.ID         `db:"id,primarykey" json:"id"`       // Unique identifier of the job (primary key)
+	BundleID uu.NullableID `db:"bundle_id"     json:"bundleId"` // ID of the JobBundle this job belongs to, or NULL for a standalone job
 
-	Type              string        `db:"type"     json:"type"` // CHECK(length("type") > 0 AND length("type") <= 100)
-	Payload           notnull.JSON  `db:"payload"  json:"payload"`
-	Priority          int64         `db:"priority" json:"priority"`
-	Origin            string        `db:"origin"   json:"origin"` // CHECK(length(origin) > 0 AND length(origin) <= 100)
-	MaxRetryCount     int           `db:"max_retry_count"   json:"maxRetryCount"`
-	CurrentRetryCount int           `db:"current_retry_count"   json:"currentRetryCount"`
-	StartAt           nullable.Time `db:"start_at" json:"startAt"` // If not NULL, earliest time to start the job
+	Type              string        `db:"type"     json:"type"`                           // CHECK(length("type") > 0 AND length("type") <= 100)
+	Payload           notnull.JSON  `db:"payload"  json:"payload"`                        // Job input data as JSON, passed to the registered worker
+	Priority          int64         `db:"priority" json:"priority"`                       // Higher priorities are started before lower ones
+	Origin            string        `db:"origin"   json:"origin"`                         // CHECK(length(origin) > 0 AND length(origin) <= 100)
+	MaxRetryCount     int           `db:"max_retry_count"   json:"maxRetryCount"`         // Maximum number of retries before the job is considered finally failed
+	CurrentRetryCount int           `db:"current_retry_count"   json:"currentRetryCount"` // Number of retries already attempted
+	StartAt           nullable.Time `db:"start_at" json:"startAt"`                        // If not NULL, earliest time to start the job
 
 	StartedAt     nullable.Time `db:"started_at"      json:"startedAt"`     // Time when started working on the job, or NULL when not started
 	WorkerAliveAt nullable.Time `db:"worker_alive_at" json:"workerAliveAt"` // Heartbeat updated periodically while a worker processes the job, NULL when not being processed. A stale value while StoppedAt is NULL indicates the worker crashed.
@@ -47,14 +47,18 @@ type Job struct {
 	ErrorData nullable.JSON           `db:"error_data" json:"errorData"` // Optional error metadata
 	Result    nullable.JSON           `db:"result"     json:"result"`    // Result if the job returned one
 
-	UpdatedAt time.Time `db:"updated_at" json:"updatedAt"`
-	CreatedAt time.Time `db:"created_at" json:"createdAt"`
+	UpdatedAt time.Time `db:"updated_at" json:"updatedAt"` // Time the row was last updated
+	CreatedAt time.Time `db:"created_at" json:"createdAt"` // Time the job was created
 }
 
+// Started returns true if a worker has claimed the job and set its StartedAt
+// timestamp. May be stale after the snapshot was loaded.
 func (j *Job) Started() bool {
 	return j.StartedAt.IsNotNull()
 }
 
+// Stopped returns true if work on the job has stopped, because it finished,
+// errored, or paused for a decision. May be stale after the snapshot was loaded.
 func (j *Job) Stopped() bool {
 	return j.StoppedAt.IsNotNull()
 }
@@ -85,6 +89,10 @@ func (j *Job) WorkerAlive(deadFor time.Duration) bool {
 	return time.Since(j.WorkerAliveAt.Get()) <= deadFor
 }
 
+// IsFinished returns true if the job has stopped and will not be retried,
+// either because it succeeded (no ErrorMsg) or because it exhausted its retries
+// (CurrentRetryCount reached MaxRetryCount). May be stale after the snapshot was
+// loaded.
 func (j *Job) IsFinished() bool {
 	if !j.Stopped() {
 		return false
@@ -92,6 +100,8 @@ func (j *Job) IsFinished() bool {
 	return j.CurrentRetryCount >= j.MaxRetryCount || j.ErrorMsg.IsNull()
 }
 
+// Succeeded returns true if the job has finished without an error.
+// May be stale after the snapshot was loaded.
 func (j *Job) Succeeded() bool {
 	return j.IsFinished() && !j.HasError()
 }

--- a/jobbundlelistener.go
+++ b/jobbundlelistener.go
@@ -4,12 +4,17 @@ import (
 	"sync"
 )
 
+// JobBundleStoppedListener is notified when all jobs in a job bundle have stopped.
 type JobBundleStoppedListener interface {
+	// OnJobBundleStopped is called once every job in the bundle has stopped.
 	OnJobBundleStopped(jobBundle *JobBundle)
 }
 
+// JobBundleStoppedListenerFunc adapts a plain function to the
+// JobBundleStoppedListener interface.
 type JobBundleStoppedListenerFunc func(jobBundle *JobBundle)
 
+// OnJobBundleStopped calls f, implementing JobBundleStoppedListener.
 func (f JobBundleStoppedListenerFunc) OnJobBundleStopped(jobBundle *JobBundle) {
 	f(jobBundle)
 }
@@ -22,6 +27,8 @@ var (
 	jobBundleOfTypeStoppedListenersMtx sync.RWMutex
 )
 
+// AddJobBundleStoppedListener registers a listener that is called whenever any
+// job bundle stops, regardless of its type.
 func AddJobBundleStoppedListener(listener JobBundleStoppedListener) {
 	jobBundleStoppedListenersMtx.Lock()
 	defer jobBundleStoppedListenersMtx.Unlock()
@@ -29,6 +36,8 @@ func AddJobBundleStoppedListener(listener JobBundleStoppedListener) {
 	jobBundleStoppedListeners = append(jobBundleStoppedListeners, listener)
 }
 
+// RemoveJobBundleStoppedListener removes a listener previously registered with
+// AddJobBundleStoppedListener. It does nothing if the listener is not registered.
 func RemoveJobBundleStoppedListener(listener JobBundleStoppedListener) {
 	jobBundleStoppedListenersMtx.Lock()
 	defer jobBundleStoppedListenersMtx.Unlock()
@@ -41,6 +50,9 @@ func RemoveJobBundleStoppedListener(listener JobBundleStoppedListener) {
 	}
 }
 
+// SetJobBundleOfTypeStoppedListener registers a listener that is called when a
+// job bundle of the given type stops. Only one listener can be set per type;
+// setting a new one replaces any previous listener for that type.
 func SetJobBundleOfTypeStoppedListener(jobBundleType string, listener JobBundleStoppedListener) {
 	jobBundleOfTypeStoppedListenersMtx.Lock()
 	defer jobBundleOfTypeStoppedListenersMtx.Unlock()
@@ -48,6 +60,9 @@ func SetJobBundleOfTypeStoppedListener(jobBundleType string, listener JobBundleS
 	jobBundleOfTypeStoppedListeners[jobBundleType] = listener
 }
 
+// RemoveJobBundleOfTypeStoppedListener removes the listener registered for the
+// given job bundle type with SetJobBundleOfTypeStoppedListener. The listener
+// argument is ignored, since only one listener exists per type.
 func RemoveJobBundleOfTypeStoppedListener(jobBundleType string, listener JobBundleStoppedListener) {
 	jobBundleOfTypeStoppedListenersMtx.Lock()
 	defer jobBundleOfTypeStoppedListenersMtx.Unlock()
@@ -55,6 +70,8 @@ func RemoveJobBundleOfTypeStoppedListener(jobBundleType string, listener JobBund
 	delete(jobBundleOfTypeStoppedListeners, jobBundleType)
 }
 
+// RemoveAllJobBundleStoppedListeners removes all registered job bundle stopped
+// listeners, both the global listeners and the per-type listeners.
 func RemoveAllJobBundleStoppedListeners() {
 	jobBundleStoppedListenersMtx.Lock()
 	jobBundleStoppedListeners = nil

--- a/joblistener.go
+++ b/joblistener.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 )
 
+// JobStoppedListener is notified when a job has stopped.
 type JobStoppedListener interface {
 	// OnJobStopped is called when a job has stopped.
 	// willRetry indicates that the job will be retried
@@ -14,8 +15,10 @@ type JobStoppedListener interface {
 	OnJobStopped(job *Job, willRetry bool)
 }
 
+// JobStoppedListenerFunc adapts a plain function to the JobStoppedListener interface.
 type JobStoppedListenerFunc func(job *Job, willRetry bool)
 
+// OnJobStopped calls f, implementing JobStoppedListener.
 func (f JobStoppedListenerFunc) OnJobStopped(job *Job, willRetry bool) {
 	f(job, willRetry)
 }
@@ -25,6 +28,7 @@ var (
 	jobStoppedListenersMtx sync.RWMutex
 )
 
+// AddJobStoppedListener registers a listener that is called whenever a job stops.
 func AddJobStoppedListener(listener JobStoppedListener) {
 	jobStoppedListenersMtx.Lock()
 	defer jobStoppedListenersMtx.Unlock()
@@ -32,6 +36,8 @@ func AddJobStoppedListener(listener JobStoppedListener) {
 	jobStoppedListeners = append(jobStoppedListeners, listener)
 }
 
+// RemoveJobStoppedListener removes a listener previously registered with
+// AddJobStoppedListener. It does nothing if the listener is not registered.
 func RemoveJobStoppedListener(listener JobStoppedListener) {
 	jobStoppedListenersMtx.Lock()
 	defer jobStoppedListenersMtx.Unlock()

--- a/jobworker/config.go
+++ b/jobworker/config.go
@@ -30,6 +30,7 @@ var (
 	typeOfContext = reflect.TypeFor[context.Context]()
 )
 
+// OverrideLogger replaces the logger used by the jobworker package.
 func OverrideLogger(logger *golog.Logger) {
 	log = logger
 }

--- a/jobworker/database.go
+++ b/jobworker/database.go
@@ -12,33 +12,64 @@ import (
 
 var db DataBase
 
+// SetDataBase sets the DataBase implementation used by the jobworker package.
+// It must be called during initialization before starting worker threads;
+// jobworkerdb.InitJobQueue does this automatically.
 func SetDataBase(newDB DataBase) {
 	db = newDB
 }
 
+// DataBase is the persistence backend the jobworker package needs in addition
+// to the jobqueue.Service interface. The jobworkerdb package provides the
+// PostgreSQL implementation and registers it with SetDataBase.
 type DataBase interface {
 	jobqueue.Service
 
+	// SetJobAvailableListener registers a callback that is invoked whenever a new
+	// job becomes available, or clears the callback when passed nil.
 	SetJobAvailableListener(context.Context, func()) error
+
+	// StartNextJobOrNil claims and starts the next available job, returning nil
+	// if no job is currently available.
 	StartNextJobOrNil(ctx context.Context) (*jobqueue.Job, error)
 
+	// SetJobError stops the job with a terminal error described by errorMsg and
+	// optional errorData, marking it as not to be retried.
 	SetJobError(ctx context.Context, jobID uu.ID, errorMsg string, errorData nullable.JSON) error
+
+	// SetJobResult stops the job successfully and stores its result.
 	SetJobResult(ctx context.Context, jobID uu.ID, result nullable.JSON) error
+
+	// SetJobStart reschedules the job to start no earlier than startAt, clearing
+	// any previous start, stop, and error state.
 	SetJobStart(ctx context.Context, jobID uu.ID, startAt time.Time) error
 
 	// SetJobWorkerAlive updates the worker_alive_at heartbeat timestamp of a job
 	// that is currently being processed.
 	SetJobWorkerAlive(ctx context.Context, jobID uu.ID) error
 
+	// ScheduleRetry reschedules the job to run again at startAt with the given
+	// retryCount, clearing any previous start, stop, and error state.
 	ScheduleRetry(ctx context.Context, jobID uu.ID, startAt time.Time, retryCount int) error
 
+	// DeleteJobsFromOrigin deletes all jobs created from the given origin.
 	DeleteJobsFromOrigin(ctx context.Context, origin string) error
+
+	// DeleteJobsOfType deletes all jobs of the given type.
 	DeleteJobsOfType(ctx context.Context, jobType string) error
+
+	// DeleteJobBundlesFromOrigin deletes all job bundles created from the given origin.
 	DeleteJobBundlesFromOrigin(ctx context.Context, origin string) error
+
+	// DeleteJobBundlesOfType deletes all job bundles of the given type.
 	DeleteJobBundlesOfType(ctx context.Context, bundleType string) error
+
+	// DeleteAllJobsAndBundles deletes all jobs and job bundles from the queue.
 	DeleteAllJobsAndBundles(ctx context.Context) error
 }
 
+// DeleteAllJobsAndBundles deletes all jobs and job bundles from the queue using
+// the DataBase set with SetDataBase. It returns an error if no DataBase has been set.
 func DeleteAllJobsAndBundles(ctx context.Context) error {
 	if db == nil {
 		return errs.New("no DataBase defined")

--- a/jobworker/scheduleretry.go
+++ b/jobworker/scheduleretry.go
@@ -8,8 +8,12 @@ import (
 	"github.com/domonda/go-jobqueue"
 )
 
+// ScheduleRetryFunc computes the next start time for a failed job that is going
+// to be retried. It is registered per job type with RegisterScheduleRetry.
 type ScheduleRetryFunc func(ctx context.Context, job *jobqueue.Job) (nextStart time.Time, err error)
 
+// RegisterScheduleRetry registers a ScheduleRetryFunc for the given job type.
+// It panics if a retry scheduler has already been registered for that type.
 func RegisterScheduleRetry(jobType JobType, scheduleFunc ScheduleRetryFunc) {
 	retrySchedulersMtx.Lock()
 	defer retrySchedulersMtx.Unlock()

--- a/jobworker/worker.go
+++ b/jobworker/worker.go
@@ -12,6 +12,9 @@ import (
 	"github.com/domonda/go-types/notnull"
 )
 
+// WorkerFunc processes a job and returns an optional result that is stored as
+// the job's result, or an error if processing failed. Register a WorkerFunc for
+// a job type with Register.
 type WorkerFunc func(ctx context.Context, job *jobqueue.Job) (result any, err error)
 
 // Register a Worker implementation for a jobType.
@@ -41,6 +44,7 @@ func IsRegistered(jobType string) bool {
 	return workers[jobType] != nil
 }
 
+// RegisteredJobTypes returns the job types that currently have a worker registered.
 func RegisteredJobTypes() notnull.StringArray {
 	workersMtx.RLock()
 	defer workersMtx.RUnlock()
@@ -188,6 +192,8 @@ func registerFunc(jobType string, workerFunc any) {
 // 	}))
 // }
 
+// Unregister removes the workers for the given job types,
+// or all registered workers if no job type is passed.
 func Unregister(jobTypes ...string) {
 	workersMtx.Lock()
 	defer workersMtx.Unlock()

--- a/jobworker/workerthreads.go
+++ b/jobworker/workerthreads.go
@@ -11,6 +11,8 @@ import (
 	"github.com/domonda/go-jobqueue"
 )
 
+// JobType identifies a kind of job. It is an alias for string so that job type
+// string literals can be used directly as map keys and function arguments.
 type JobType = string
 
 var (

--- a/jobworkerdb/context.go
+++ b/jobworkerdb/context.go
@@ -8,30 +8,44 @@ import (
 
 var synchronousJobsKey int
 
+// ContextWithSynchronousJobs returns a context that makes added jobs run inline
+// (synchronously) instead of being persisted to the database for a worker to
+// pick up. Use SynchronousJobs to test a context for this flag.
 func ContextWithSynchronousJobs(ctx context.Context) context.Context {
 	return context.WithValue(ctx, &synchronousJobsKey, struct{}{})
 }
 
+// SynchronousJobs reports whether ctx was marked for synchronous job execution
+// by ContextWithSynchronousJobs.
 func SynchronousJobs(ctx context.Context) bool {
 	return ctx.Value(&synchronousJobsKey) != nil
 }
 
 var ignoreJobKey int
 
+// IgnoreJobFunc reports whether the given job should be ignored,
+// meaning silently discarded instead of added to the queue.
 type IgnoreJobFunc func(*jobqueue.Job) bool
 
+// IgnoreAllJobs is an IgnoreJobFunc that ignores every job.
 func IgnoreAllJobs(*jobqueue.Job) bool { return true }
 
+// ContextWithIgnoreJob returns a context whose added jobs are silently discarded
+// when ignoreJob returns true. The filter is applied by IgnoreJob.
 func ContextWithIgnoreJob(ctx context.Context, ignoreJob IgnoreJobFunc) context.Context {
 	return context.WithValue(ctx, &ignoreJobKey, ignoreJob)
 }
 
+// ContextWithIgnoreJobType returns a context that silently discards added jobs
+// whose Type equals ignoreJobType.
 func ContextWithIgnoreJobType(ctx context.Context, ignoreJobType string) context.Context {
 	return ContextWithIgnoreJob(ctx, func(job *jobqueue.Job) (ignore bool) {
 		return job.Type == ignoreJobType
 	})
 }
 
+// IgnoreJob reports whether job should be ignored according to the IgnoreJobFunc
+// stored in ctx by ContextWithIgnoreJob. It returns false if no filter is set.
 func IgnoreJob(ctx context.Context, job *jobqueue.Job) bool {
 	if ignoreJob, ok := ctx.Value(&ignoreJobKey).(IgnoreJobFunc); ok {
 		return ignoreJob(job)
@@ -41,14 +55,23 @@ func IgnoreJob(ctx context.Context, job *jobqueue.Job) bool {
 
 var ignoreJobBundleKey int
 
+// IgnoreJobBundleFunc reports whether the given job bundle should be ignored,
+// meaning silently discarded instead of added to the queue.
 type IgnoreJobBundleFunc func(*jobqueue.JobBundle) bool
 
+// IgnoreAllJobBundles is an IgnoreJobBundleFunc that ignores every job bundle.
 func IgnoreAllJobBundles(*jobqueue.JobBundle) bool { return true }
 
+// ContextWithIgnoreJobBundle returns a context whose added job bundles are
+// silently discarded when ignoreJobBundle returns true. The filter is applied
+// by IgnoreJobBundle.
 func ContextWithIgnoreJobBundle(ctx context.Context, ignoreJobBundle IgnoreJobBundleFunc) context.Context {
 	return context.WithValue(ctx, &ignoreJobBundleKey, ignoreJobBundle)
 }
 
+// IgnoreJobBundle reports whether jobBundle should be ignored according to the
+// IgnoreJobBundleFunc stored in ctx by ContextWithIgnoreJobBundle. It returns
+// false if no filter is set.
 func IgnoreJobBundle(ctx context.Context, jobBundle *jobqueue.JobBundle) bool {
 	if ignoreJobBundle, ok := ctx.Value(&ignoreJobBundleKey).(IgnoreJobBundleFunc); ok {
 		return ignoreJobBundle(jobBundle)

--- a/servicelistener.go
+++ b/servicelistener.go
@@ -7,6 +7,9 @@ import (
 	"github.com/domonda/go-types/uu"
 )
 
+// ServiceListener receives job and job bundle completion events from a Service.
+// A Service forwards these events to the package-level job and job bundle
+// stopped listeners; see NewDefaultServiceListener for the standard implementation.
 type ServiceListener interface {
 	// OnJobStopped is called when a job has stopped.
 	// willRetry indicates that the job will be retried
@@ -15,9 +18,16 @@ type ServiceListener interface {
 	// reset for retry by the time the handler reads it from the database,
 	// so its state may no longer reflect the error that triggered this notification.
 	OnJobStopped(ctx context.Context, jobID uu.ID, jobType, jobOrigin string, willRetry bool)
+
+	// OnJobBundleStopped is called when every job in a job bundle has stopped.
 	OnJobBundleStopped(ctx context.Context, jobBundleID uu.ID, jobBundleType, jobBundleOrigin string)
 }
 
+// NewDefaultServiceListener returns the standard ServiceListener implementation.
+// It loads the affected job or job bundle from service and dispatches to the
+// listeners registered via AddJobStoppedListener, AddJobBundleStoppedListener,
+// and SetJobBundleOfTypeStoppedListener. A bundle that completed without errors
+// is deleted from the queue.
 func NewDefaultServiceListener(service Service) ServiceListener {
 	return defaultServiceListener{Service: service}
 }

--- a/tests/jobexecution_test.go
+++ b/tests/jobexecution_test.go
@@ -307,11 +307,17 @@ func TestSimulateJobs(t *testing.T) {
 	})
 }
 
+// PartialLogRecord is the subset of a JSON log record that the tests inspect.
 type PartialLogRecord struct {
-	Level   string `json:"level"`
-	Message string `json:"message"`
+	Level   string `json:"level"`   // Log level such as "ERROR"
+	Message string `json:"message"` // Log message text
 }
 
+// NewRegisteredJobWithWaiter registers workerFunc (and an optional retry
+// scheduler) for jobType, adds a single job with the given retryCount to the
+// queue, starts one worker thread, and returns the job together with a Waiter
+// that blocks until the job is finished. All registrations and threads are
+// cleaned up when the test ends.
 func NewRegisteredJobWithWaiter(
 	t *testing.T,
 	workerFunc jobworker.WorkerFunc,
@@ -354,6 +360,7 @@ func NewRegisteredJobWithWaiter(
 	return job, NewJobWaiter(t.Context(), t, jobID)
 }
 
+// NewJobWaiter returns a Waiter that polls the job with jobID until it is finished.
 func NewJobWaiter(ctx context.Context, t *testing.T, jobID uu.ID) *Waiter {
 	t.Helper()
 
@@ -368,12 +375,15 @@ func NewJobWaiter(ctx context.Context, t *testing.T, jobID uu.ID) *Waiter {
 	}
 }
 
+// Waiter polls a condition until it becomes true or a timeout elapses.
 type Waiter struct {
-	Check         func() bool
-	Timeout       time.Duration
-	PollFrequency time.Duration
+	Check         func() bool   // Condition polled until it returns true
+	Timeout       time.Duration // Maximum time to wait before giving up
+	PollFrequency time.Duration // Delay between successive Check calls
 }
 
+// Wait polls Check every PollFrequency until it returns true, or returns an
+// error if Timeout elapses first.
 func (w *Waiter) Wait() error {
 	start := time.Now()
 	for {


### PR DESCRIPTION
Adds Go doc comments to every exported identifier that lacked one across the `jobqueue`, `jobworker`, and `jobworkerdb` packages, including types, functions, methods, constants, struct fields, and interface methods, plus the exported test helpers. Comments were verified against the implementation (e.g. `SetJobStart`, `IsFinished`, the `DataBase` interface methods) and follow each file's existing style. No behavior changes: `go build ./...`, `go vet ./...`, and `gofmt -l` are all clean, and `revive`'s exported rule plus an AST sweep report zero remaining undocumented exported names.